### PR TITLE
feat(action): use packages only for checking cache

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,12 +17,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node
           token: ${{ secrets.ORG_PAT }}
-          package-name: "npm-ci"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run-action.yml
+++ b/.github/workflows/run-action.yml
@@ -106,12 +106,21 @@ jobs:
           name: test_package_node_${{ inputs.node_major }}
           path: testing
 
-      - name: Get Cache Key
-        id: cache-key
+      - name: Alter package-lock version
         shell: pwsh
         run: |
-          $key = "${{ inputs.runs_on }}-${{ hashFiles('**/package-lock.json') }}"
-          Write-Output "key=${key}" >> $env:GITHUB_OUTPUT
+            $packageLocks = Get-ChildItem -Path testing -Filter 'package-lock.json' -Recurse
+            foreach ($packageLock in $packageLocks)
+            {
+                $lockPath = $packageLock.FullName
+                $lockContent = Get-Content -Path $lockPath -Raw `
+                    | ConvertFrom-Json -AsHashTable
+
+                $lockContent.version = "9.9.9"
+
+                $lockContent | ConvertTo-Json -Depth 100 `
+                    | Set-Content -Path $lockPath
+            }
 
       - name: Download action
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -54,7 +54,7 @@ jobs:
     if: github.event.action != 'closed'
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
     steps:
       - name: "Use Node.js (${{ matrix.node-version }}.x)"
         uses: actions/setup-node@v4
@@ -102,17 +102,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - os: macos-latest
-            node-version: 14
-          - os: macos-latest
-            node-version: 16
-          - os: windows-latest
-            node-version: 14
-          - os: windows-latest
-            node-version: 16
     uses: ./.github/workflows/run-action.yml
     with:
       node_major: ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## chill-viking/npm-ci
 
-This GitHub action will install npm dependencies, using cache if already cached. The cache is based on available `package-lock.json` files in source.
+This GitHub action will install npm dependencies, using cache if already cached. The cache is based on packages found in `package-lock.json` files in source, which are stored as `packages-only-lock.json` over the course of the action.
 
 Will log a warning if `node_modules` folder is not found after installing the dependencies.
 

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: Use node_modules from cache [npm]
       id: cache-node
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-node-modules
       with:

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,26 @@ runs:
           Write-Output "path=${input}" >> $env:GITHUB_OUTPUT
         }
 
+    - name: Create packages-only packge-lock
+      shell: pwsh
+      run: |
+        $packageLocks = Get-ChildItem -Path ${{ steps.working_directory.outputs.path }} -Filter 'package-lock.json' -Recurse
+        foreach ($packageLock in $packageLocks)
+        {
+          $lockDirectory = $packageLock.Directory.FullName
+          $lockPath = $packageLock.FullName
+          $lockContent = Get-Content -Path $lockPath -Raw `
+            | ConvertFrom-Json -AsHashTable
+
+          $packagesOnly = @{
+            packages = $lockContent.packages
+          }
+
+          Write-Output "$lockPath -> $lockDirectory/packages-only-lock.json"
+          $packagesOnly | ConvertTo-Json -Depth 100 `
+            | Set-Content -Path "$lockDirectory/packages-only-lock.json"
+        }
+
     - name: Use node_modules from cache [npm]
       id: cache-node
       uses: actions/cache@v3
@@ -45,8 +65,9 @@ runs:
       with:
         # caching node_modules
         path: ${{ steps.working_directory.outputs.path }}node_modules
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**//packages-only-lock.json') }}
         restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-
           ${{ runner.os }}-
@@ -57,6 +78,12 @@ runs:
       if: steps.cache-node.outputs.cache-hit != 'true'
       run: |
         npm ci
+
+    - shell: pwsh
+      name: Clear package only lock files
+      run: |
+        Get-ChildItem -Path ${{ steps.working_directory.outputs.path }} -Filter 'packages-only-lock.json' -Recurse `
+          | Remove-Item
 
     - shell: pwsh
       name: Check path for cache


### PR DESCRIPTION
## 🎉 Description

Updated action to create `packages-only-lock.json`, with `packages` property from found `package-lock.json` files from working directory.

Should prevent changes to `package-lock.json` that do not affect installed packages from causing `npm ci` being incorrectly used in the action.

Fixes #72

## 🚀 Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🆕 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Chore (non-breaking and non-functional change)

## 🧪 How Has This Been Tested?

- [x] Tests in workflow updated to adjust `version` of `package-lock.json` file, testing in pull request run.

## 🧾 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
